### PR TITLE
1 line comments don't require thriple quotes fwiw

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Django's command-line utility for administrative tasks."""
+#Django's command-line utility for administrative tasks.
 import os
 import sys
 


### PR DESCRIPTION
ps. I'm just testing out pull requests.
Instead of
```py
"""Django's command-line utility for administrative tasks."""
```
this follows my sanity:
```py
#Django's command-line utility for administrative tasks.
```